### PR TITLE
add composer.json to reuse for PHP develop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "woothee/woothee-testset",
-    "description": "it is test set",
+    "description": "Set of test case for woothee project. Project Woothee is multi-language user-agent strings parsers.",
     "license": "Apache-2.0",
     "authors": [
         {


### PR DESCRIPTION
Add composer.json to reuse for PHP develop.
and Could you consider register this repository to packagist.org ?
- composer
  https://getcomposer.org/doc/00-intro.md
- to submit Packagist
  https://packagist.org/packages/submit

If you finished to register into packagist, we can setup simply like as below.
`php composer.phar require woothee/woothee`
