### PR TITLE
Add case for Android KitKat webview

### DIFF
--- a/testsets/smartphone_android.yaml
+++ b/testsets/smartphone_android.yaml
@@ -72,6 +72,14 @@
   os: Android
   category: smartphone
 
+# Webview + Android (KitKat)
+- target: 'Mozilla/5.0 (Linux; Android 4.4.4; ko-kr; SAMSUNG SM-G710K/KTUBPK1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36'
+  name: 'Webview'
+  version: '1.5'
+  os: Android
+  os_version: '4.4.4'
+  category: smartphone
+
 # Webview + Android(Lollipop and Above)
 - target: 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36'
   name: 'Webview'


### PR DESCRIPTION
Currently it's impossible to detect webview on Android KitKat. A user agent
```
Mozilla/5.0 (Linux; Android 4.4.4; ko-kr; SAMSUNG SM-G710K/KTUBPK1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
```
gets recognized as a plain Chrome Android browser. 

Based on [Chrome Doc about UA on different devices](https://developer.chrome.com/multidevice/user-agent#webview_user_agent), this PR adds a testcase for KitKat case described in the link.