### PR TITLE
add SamsungBrowser

### DIFF
--- a/dataset.yaml
+++ b/dataset.yaml
@@ -53,6 +53,11 @@
   type: browser
   vendor: Yandex
 
+- label: SamsungBrowser
+  name: SamsungBrowser
+  type: browser
+  vendor: Samsung
+
 - label: Win
   name: Windows UNKNOWN Ver
   type: os

--- a/testsets/smartphone_android.yaml
+++ b/testsets/smartphone_android.yaml
@@ -87,3 +87,11 @@
   os: Android
   os_version: '9'
   category: smartphone
+
+# SamsungBrowser + Android
+- target: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-G925F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36'
+  name: SamsungBrowser
+  version: '4.0'
+  os: Android
+  os_version: '5.0.2'
+  category: smartphone


### PR DESCRIPTION
fix #56

Add SamsungBrowser, the 3rd on "[Mobile Browser Market Share Worldwide](https://gs.statcounter.com/browser-market-share/mobile/worldwide)"