### PR TITLE
remove applebot from google's crawler testset

### DIFF
--- a/testsets/crawler_google.yaml
+++ b/testsets/crawler_google.yaml
@@ -53,11 +53,6 @@
   os: UNKNOWN
   category: crawler
 
-- target: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)'
-  name: AdsBot-Google-Mobile
-  os: UNKNOWN
-  category: crawler
-
 - target: 'AdsBot-Google (+http://www.google.com/adsbot.html)'
   name: AdsBot-Google
   os: UNKNOWN


### PR DESCRIPTION
## How about this?

Fixes https://github.com/woothee/woothee/pull/55#discussion_r467684031

The Google Bot description page in [the commit log](https://github.com/woothee/woothee/pull/55/commits/d45824718c5577253fc36372b89334c7a1f3c706) does not contain the word Applebot, so I deleted the test data.

ref: [Overview of Google crawlers (user agents)  |  Search Central](https://support.google.com/webmasters/answer/1061943)