### PR TITLE
change mac os name

### DIFF
--- a/dataset.yaml
+++ b/dataset.yaml
@@ -129,7 +129,7 @@
   category: smartphone
 
 - label: OSX
-  name: Mac OSX
+  name: macOS
   type: os
   category: pc
 

--- a/testsets/pc_misc.yaml
+++ b/testsets/pc_misc.yaml
@@ -2,7 +2,7 @@
 - target: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4; ja-jp) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.20.1'
   name: Safari
   version: 3.1.2
-  os: Mac OSX
+  os: macOS
   os_version: '10.5.4'
   category: pc
 
@@ -10,7 +10,7 @@
 - target: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36'
   name: Chrome
   version: 27.0.1453.93
-  os: Mac OSX
+  os: macOS
   os_version: '10.7.5'
   category: pc
 
@@ -18,7 +18,7 @@
 - target: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:21.0) Gecko/20100101 Firefox/21.0'
   name: Firefox
   version: '21.0'
-  os: Mac OSX
+  os: macOS
   os_version: '10.7'
   category: pc
 
@@ -26,7 +26,7 @@
 - target: 'Opera/9.80 (Macintosh; Intel Mac OS X 10.8.3) Presto/2.12.388 Version/12.15'
   name: Opera
   version: '12.15'
-  os: Mac OSX
+  os: macOS
   os_version: '10.8.3'
   category: pc
 
@@ -34,7 +34,7 @@
 - target: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.154 Safari/537.36 OPR/20.0.1387.82'
   name: Opera
   version: '20.0.1387.82'
-  os: Mac OSX
+  os: macOS
   os_version: '10.9.2'
   category: pc
 
@@ -42,20 +42,20 @@
 - target: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36 Vivaldi/1.1.453.52'
   name: Vivaldi
   version: '1.1.453.52'
-  os: Mac OSX
+  os: macOS
   os_version: '10.11.4'
   category: pc
 
 # Instapaper + OSX
 - target: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)'
   name: UNKNOWN
-  os: Mac OSX
+  os: macOS
   category: pc
 
 # SeaMonkey + OSX(PPC)
 - target: 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.5; ja-JP-mac; rv:1.9.1.19) Gecko/20110420 SeaMonkey/2.0.14'
   name: UNKNOWN
-  os: Mac OSX
+  os: macOS
   os_version: '10.5'
   category: pc
 


### PR DESCRIPTION
I think its time to change the os name from mac OSX to mac OS, as macOS is now the official name.
https://en.wikipedia.org/wiki/MacOS_version_history